### PR TITLE
Support custom mappings for next/prev match

### DIFF
--- a/doc/searchindex.txt
+++ b/doc/searchindex.txt
@@ -57,6 +57,12 @@ OPTIONS                                         *searchindex-options*
   used to prevent slowing down search in huge files (although note that after
   initial search is done, stepping with |n| / |N| is fast due to caching).
 
+*g:searchindex_next_key*          (default: "n")
+
+  SearchIndex will use this key to jump to the next match, and this key
+  uppercase to jump to the previous. On some layouts it is convenient to remap
+  several keys to make hjkl work, and you may want to remap |n| as well.
+
 KNOWN ISSUES                                    *searchindex-issues*
 
 Although I put a lot of effort into making SearchIndex robust, there are still

--- a/plugin/searchindex.vim
+++ b/plugin/searchindex.vim
@@ -34,6 +34,10 @@ if !exists('g:searchindex_improved_star')
   let g:searchindex_improved_star=1
 endif
 
+if !exists('g:searchindex_next_key')
+    let g:searchindex_next_key='n'
+endif
+
 if !exists('g:searchindex_star_case')
   let g:searchindex_star_case=1
 endif
@@ -55,8 +59,10 @@ noremap! <Plug>SearchIndex <Nop>
 nnoremap <silent> <Plug>SearchIndex :call <SID>PrintMatches()<CR>
 
 " Remap search commands.
-nmap <silent> n n<Plug>SearchIndex
-nmap <silent> N N<Plug>SearchIndex
+exec 'nmap <silent> ' . g:searchindex_next_key .
+\ ' :normal! n<CR><Plug>SearchIndex'
+exec 'nmap <silent> ' . toupper(g:searchindex_next_key) .
+\ ' :normal! N<CR><Plug>SearchIndex'
 
 map  *  <Plug>ImprovedStar_*<Plug>SearchIndex
 map  #  <Plug>ImprovedStar_#<Plug>SearchIndex


### PR DESCRIPTION
Hi!

I had some trouble using this plugin with Colemak layout. I have several keys remapped in order for hjkl movement to work, and 'n' is among them. This plugin maps 'n' to something and assumes that at the moment 'n' means "go to the next match", which is not true in my case. I suggest a little change which allows to customize which key is used for jumping to the next/previous match.