### PR TITLE
fix a side effect of the plugin: the last substitute string is overwritten

### DIFF
--- a/plugin/searchindex.vim
+++ b/plugin/searchindex.vim
@@ -112,7 +112,7 @@ function! s:MatchesInRange(range)
   let saved_marks = [ getpos("'["), getpos("']") ]
   let output = ''
   redir => output
-    silent! execute 'keepjumps ' . a:range . 's///en' . gflag
+    silent! execute 'keepjumps ' . a:range . 's//~/en' . gflag
   redir END
   call setpos("'[", saved_marks[0])
   call setpos("']", saved_marks[1])


### PR DESCRIPTION
…itten

Before the change the call to s:MatchesInRange sets the last substitute string to `''`